### PR TITLE
DataLoader + MNIST/LeNet notebooks

### DIFF
--- a/HKML DataLoader.ipynb
+++ b/HKML DataLoader.ipynb
@@ -1,0 +1,419 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Data loading for training \n",
+    "\n",
+    "Fast streaming of data is extremely important for training ML algorithms. As such, ML libraries including `pytorch` provide useful APIs to load data during training. In this notebook, we go over an example of how to implement `pytorch` APIs for streaming the workshop data.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from __future__ import print_function\n",
+    "import numpy as np\n",
+    "import os, time\n",
+    "import matplotlib.pyplot as plt\n",
+    "%matplotlib inline"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "There are 2 base `pytorch` modules to be implemented:\n",
+    "* `Dataset` ... represents a blob data instance, defines how data should be read from file, etc.\n",
+    "* `DataLoader` ... for streaming data segments from `Dataset`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from torch.utils.data import Dataset, DataLoader"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Dataset\n",
+    "`Dataset` module needs implementation of two attributes: `__len__` (length of our dataset) and `__getitem__` (called to fetch an item in the ordered dataset). Below, we define `HKDataset` which reads data from files whenever requested."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class HKDataset(Dataset):\n",
+    "\n",
+    "    def __init__(self, data_dirs, transform=None):\n",
+    "        \"\"\"\n",
+    "            Args: data_dirs ... a list of data directories to find files (up to 10 files read from each dir)\n",
+    "                  transform ... a function applied to pre-process data \n",
+    "        \"\"\"\n",
+    "        self._transform = transform\n",
+    "        self._files = []\n",
+    "        \n",
+    "        # Load files (up to 10) from each directory in data_dirs list\n",
+    "        for d in data_dirs: self._files += [ os.path.join(d,f) for f in os.listdir(d)[0:10] ]\n",
+    "\n",
+    "        # Need to know the total number of events. Compute.\n",
+    "        num_events_v = [np.load(f)['labels'].shape[0] for f in self._files]\n",
+    "        length = np.sum(num_events_v)\n",
+    "        \n",
+    "        # When an event is requested, need to know which file it comes from. Create a file/event index.\n",
+    "        self._file_index  = np.zeros([length],dtype=np.int32)\n",
+    "        self._event_index = np.zeros([length],dtype=np.int32)\n",
+    "        ctr=0\n",
+    "        for findex,num_events in enumerate(num_events_v):\n",
+    "            self._file_index  [ctr:ctr+num_events] = findex\n",
+    "            self._event_index [ctr:ctr+num_events] = np.arange(num_events)\n",
+    "            ctr += num_events\n",
+    "\n",
+    "    def __len__(self):\n",
+    "        return len(self._file_index)\n",
+    "            \n",
+    "    def __getitem__(self,idx):\n",
+    "        # Read data file for the specified index=idx\n",
+    "        f = np.load(self._files[self._file_index[idx]])\n",
+    "        # Retrieve event index in this file that corresponds to overall index=idx\n",
+    "        i = self._event_index[idx]\n",
+    "        # Retrieve data & label\n",
+    "        label = f['labels'][i]\n",
+    "        data  = f['event_data'][i]\n",
+    "        # Apply transformation function if necessary\n",
+    "        if self._transform is not None:\n",
+    "            data = self._transform(data)\n",
+    "        return data,label,idx"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's instantiate `HKDataset` and try loading data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "25593 total events are loaded!\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Data directories: let's use e- and mu-\n",
+    "DATA_DIRS = ['/scratch/kterao/hkml_data/2d/muminus','/scratch/kterao/hkml_data/2d/eminus']\n",
+    "# Craete an instance\n",
+    "ds = HKDataset(DATA_DIRS)\n",
+    "print(len(ds),'total events are loaded!')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Access \"5th event\" and visualize"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Entry 5 ... label: 2 ... data shape: (128, 128, 2)\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAQUAAAD8CAYAAAB+fLH0AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMi40LCBodHRwOi8vbWF0cGxvdGxpYi5vcmcv7US4rQAAIABJREFUeJztnXuQXGd14H+nu+ehGc1bI2mskRnJko2E4gcrsBwIm2AozKMwZL0EQoJCvOXdhCSETS0xobaSVG1VQiUVQkICKx7ByZqncYLDy9jGJBDwQ8JGtmzLlvWWNdJYz/HoMdM93/5x7h11z9zpud197+3bPedXpdJ09+17v/5u9/nOOd95iHMOwzAMn0y9B2AYRrowoWAYRgkmFAzDKMGEgmEYJZhQMAyjBBMKhmGUYELBMIwSYhMKInKTiOwWkT0icntc1zEMI1okjuAlEckCzwJvBA4DjwLvcc49FfnFDMOIlFxM5301sMc5txdARL4M3AwECoVWaXPtdMY0FMMwAMY59aJzbnCh4+ISCquAQ0WPDwPXFx8gIrcBtwG008H1cmNMQzEMA+B+d9eBMMfVzdHonNvmnNvsnNvcQlu9hmEYxiziEgpHgNVFj4e95xIhu2I52RXL4zl3b08s5zWMtBCXUHgUWC8ia0SkFXg3cE9M1zIMI0Ji8Sk45/Ii8jvAvUAW+Lxzblcc1wrk4sXYTl04fSa2cxtGGojL0Yhz7tvAt+M6v2EY8RCbUKgntppXTqajA4Dpc+fqPBKj3liYs2EYJTSlpmBUjmkIhk9TagrZZQNklw3UexiLhuzgINnBBQPljIiIe76bUigYhlE9TWk+FF48Ue8hpIZMVxcA0+PjsV2jMDYW27mNucQ936YpGIZRggmFCPBX4zQyPT4eq5aQBJn2djLt7fUexqIhFUJBclmyA/31HkbVNNqPrpYfWT2citMXLjB94UKi10wrfjxJrNeI/QqGYTQUqXA0unyBwomT9R5GYmR7e+oadVnLqmtOxfqSRDyJaQqGYZRgQqEOWG6GkWZMKBiGUYIJBcMwSjChYBhGCSYUDMMooWmEQpzFWpMm09lJptP6YDQzmY6OqgKRkgjyaxqhYBhGNKQieCkKCseO13sIkTE9MVHvIRgxU20QUhJBfqYpGIZRggkFwzBKaEihkB3ob+isSsNIMw0pFAzDiI+GcjT6fRwXU0ZlM5KGHhPZvj4Kp07V7frlqPf8VK0piMhqEXlQRJ4SkV0i8kHv+X4RuU9EnvP+74tqsIXTZyyZqAmYPneu7iXl0yoQoP7zU4v5kAf+wDm3EdgCfEBENgK3Aw8459YDD3iPDcNoEKoWCs65o865n3p/jwNPA6uAm4E7vMPuAN5R6yANYz6y3d1ku7sX7fXjIBKfgoiMANcBDwMrnHNHvZdGgRXzvOc24DaAduKvO2cYRjhqFgoishT4OvD7zrmzIjLzmnPOiYgLep9zbhuwDaBb+gOPMYyFKJw9G+n5ZpzZIX1X5a7vb5s3mmO8JqEgIi2oQLjTOXe39/QxERlyzh0VkSGgqvhjPyHIQn6bA7+NX9ob9UTpyE6DMMh0dFTstKxl90GAzwFPO+f+quile4Ct3t9bgW9Uew3DMJKnFk3hNcCvA0+IyOPec38E/DnwVRG5FTgAvKuakyepIWT7dNc0zdtUjU7aNYTEyGT1/+nCgodmB/pr1jaq2dqsWig4534EyDwv31jteQ3DqC8NFdEYF6YhLB6SaLhblhAagk+9fBKW+2AYRgmmKTQ5dV8ZU4bNw8KYUGhy7EfQHPjCXXK52M1dMx8MwyjBhEJM+JLdCEcz5hBEiZucxE1OJuIUN6FgGEYJ5lOICbPlKyPqHIZmw128mNi1TFNYhGTa28m0t9d7GKkhOzhIdnAwkWtJWxvS1pbItarFhIJhGCWY+bAA/gpSGBur80iiY/rChXoPIVUkeW+TNAOqxTQFwzBKWFyaQiZbUew5NJeG0IhIW1tDrK6VkuZ6IYtLKFQoEBqOKoRe2mkGgRBUYCaNwsDHzAfDMEpoak3Bj5BbNHvgTaYlNAuNVmDGNAXDMEpoOk0h09k5Y68tGg3BMCLENAXDMEpInVAoF4IbJkQ0Ca9uprNzZkupEWn2jMRGvz/1JnXmQ7lou7RsT6VtO0laWgFwU5Ohjm92s8q/P9U0Y6l3x+c0kDpNwTCM+pI6TcGonLAawmKjmmrIi1lD8DFNwTCMEmoWCiKSFZHHROSb3uM1IvKwiOwRka+ISGvtw4yGxeh8avTaCUnVOUg72YH+GR9J3EShKXwQeLro8ceAjzvn1gGngFsjuEYk1KMVXS1kurrK1nrM9vbMdEmej+kLF+Y4b3NDK8kNrSw917KBmRj9NO1ONGtCWph7B5eEQeHEybLmUJSFYmoSCiIyDLwV+Kz3WIDXA3d5h9wBvKOWaxiGkSy1Ohr/Gvgw4C9nA8Bp51zee3wYWFXjNRqSsFV3y20nLlTnsVzbdN9kCNrizR8dnXuuovj8Rt2yjCMdOSh/JooGO2Fb3pfTDorHEaVGVUsr+rcBx51zO6p8/20isl1Etk+RjvgDwzBqb0X/dhF5C9AOdAOfAHpFJOdpC8PAkaA3O+e2AdsAuqXf1TCOmsmuWA5A4djxxK8dZjsx290NXiTnQitCOQ0hLL4/pNoeA/UqYReHzyhIa4qrUrfvYwirRcQ1jqo1BefcR5xzw865EeDdwPedc+8FHgRu8Q7bCnyj5lEahpEYcQQv/SHwZRH5P8BjwOeiOnGtK1jgObu766IhBDGff6ESGz+Koqw1z2+F4eiZjg4LGmKuhuDvOiRNJELBOfcD4Afe33uBV0dx3tmE+bJKLofL5xc8buac8/zgKjEpKr3mfDRLZGKljsrpc+eqylNodornIsn5sYhGwzBKaJjch2x3d6gVyOXzlZsZmaz+X1TOLIyGEIc5s1gxDaE8Sc6PaQqGYZTQMJpCJXZqxSt3QMHTMHn1SWoIlW5XRXlNV5gGotsCq8dnMcLTMEIhiDgbhcTtDc+tXAFAfvQYoNFp/o8uKGKu0h9QFKZN2YjJkFF9QT0PfCHjRyBmVgyS37u/orHNnr+wNFqF73o4YM18MAyjhNRrCuUi9KLWEuJaRYIi/GavcMUrbhRqetymTdAYg8wCN6wrem7JEn3f6TNIa4v+veYyPWb8AnLdK/Qcp/S87rze7/kcvpVqCD6NoiH41MMBa5qCYRglpF5TSLJtelyrSLkcgNC2eUgfQZyFRxeKsAvyQUw//hQAU7/0Sh3f5DLE8ylMLVWNoX3iIhNrluo1hnT8rae8QK4rhsj+dLeeK8HvQsMRsK1eLakXCuXILhtouJZcswlrKoQ1ByoRBrmhlTNp1GF2BBZSZXOrh3UMffoDz5w9x/i1Wsyl/biaei0HxnAdahJe7B+YeW/XLr2PU4P63lMbVDgUWiF71XUADD6i15eTZ+akf2cHB3HeZ09bte0kyHbrvEWxo2Pmg2EYJTS0ptDoWkK9yR8dnWOWBGlfCxUvmbjlegCWHtCV+vhmXbWWvNhD135Pc5lWkwER3KiaUx1jeh03OTWj4WR6fg6A5d87qK91tOM6NG38+Bbdnlv+9YAiMSku27bQtmIl6e6Z9vbA46KM+TBNwTCMElKnKVi2XHwEBfzM9lUEaV9BGoJ/n/b/1ssZ+aqez3lbjYOf+gkAmWs3zjga/W1Z19+DO6aruqwf0ePOTsC6ywE48GGtt7P8c7pd2fadR8mt1eOW7VRn2vktV7Jkn467sHvPpTGtX6vPPbd33jkIolhbiiPacqHvsh/MFYYknK2mKRiGUULqNIXFqiFk+/piDziqNuAnkGWqKfQ9Ow1j3j27XHcaMptero+fPzSjIUyP6Gunr+xk4Jyuds6pVjBx9WXkzutW2uV/prsU41eoVtD6mmvJ/8fjAMgR9S0s6e3h7GvXANB1+Kief2JijoZQHIxWbuu3eN7rkY/h19Eot52cZHh26oRCOXyHjLR79QqbKKGmcOrUnBsfR3XiMJRTof3X8svUmdh+Ygrp8Yp5H9How6kNagq0jvdy/io1WQ7+hhah6b9XcN36uZ57nwqW4QfznF6n93TF/Wq+LM2qEpvd+wLn37S5ZAxt399Jx6gKjxO3XK3n/eIOMt62HIXCnPHXGiVanJsSF2WT72oQBrlVaopxONzxZj4YhlGC+CpcPemWfne93FjTORot+61axKvq7C5erEvbdN/pl1/udZB6aOeMRjN+0yYAMnn9Tp1Zm2PVv6p6f/4KDVRa8sjzSJtfi3JKz7F8AHfY22a8YjUAcl5Vark4yXSPnn9ymX7esy9rZfAh1SiOvVbPu+JHJyg89WxFn6V4Ln3mMzOiysj1td2M56jNH3lh5rW4v8P3u7t2OOc2L3ScaQqGYZTQUD6FcpR08KmTLZ4ExatVpRpCpdtts1fNyZteRe4JbeORPavOwunNmxgf0fluO6V+g8O/pJrAuk8+jzt3Xt97nRbC7ejrwXn+gvFN6oTsenKMTLd3rbyXF7FSH48PtzHwI71mq4hepzfHsV9QDaF3j2oUq79wiEe+8PMALP/7H+sYF+g/EbTyz+c3iCoj199SnC7SEHzi0BCq8YU0jVAoJtK2YREUK4mizVhYyrWh84VB2FiQ2ePt2H0ccror4Fr1q+O2P4lbuwWAozeoOj7yzZf0te6lnP7PukuQu6A/9okNgyw5ovfnyOv1vKsYpHO/vkd279Pj96kAaO19xYyzstCmwqTz6w+z1Eu1zoyrYDz03iGGjj2px/mft0yUY5Ll06No0FOM5Ly5D1FBvJrvnJkPhmGU0JSaQpSE0hAy2bIpq3FrCMWRimF6R1S6Qk7/gmYpFs5NMtWjq16+QzWGzv09TG1Vp9/yT/YCkLmgK9jUUDfde1UryB7WVTu/epAT16oZ079Tz99xdAKyqhnIiGZanrxOtZn+h49BVq+150/V0djfs4X+x/S+THd5ztaOFg5s1Xm44hMa5VhOU1hoDoI0xHLmiK99uUl1npYUzYk4CrHSHiO+pkpI68Q0BcMwSqhJUxCRXuCzwCbAAb8J7Aa+AowA+4F3OeeauzFCBIUtggi75RgqUlEEKtx+9rtkZXZokRMZGUa61W/Q+SN9buK1V/HST/Rr1D9a6sBs3TvG5MuW6bkyXjDSMwfoL+i244WV+vmyJyeQi6rhOG+7sufOhwB47ovXsvavdX5HPqHaxImfE+S8Ov6yp3VFPvgbIwz9WFfp/DoN1pEFMieDtiR9gjTEajWPevcHSdrR+Angu865W0SkFegA/gh4wDn35yJyO3A72l+yKsrduGannDCouMBMNfEoXbqrMLVRVfq2fS8ysVLV5BZPTT50S4ENf6yxCBObvFDmtZoYJYVeWsf1uste0B87SwbY/dtar/HKz+g9nRrqpuUpDbcTT3hM3vQqANb/yUkOvlPNgsv/RSMmlz8yNbOD4QZ0b7/zqCO/RJ87e7kKm8GflP94SX2nGq1ZUNXmg4j0AK/DayDrnJt0zp0Gbgbu8A67A3hHrYM0DCM5atEU1gBjwD+IyDXADuCDwArn3FHvmFFgRS0DXIwagk85x5Zf7Xje9wZEx5VTY/3XXD5/Sd30UqHb9nvFUNpacV4pwHM3avTikt05NU2A6Rb9P3detYPug1Mz24hTQ54TcrLAxj/R6EXftGh9/jgv/Mp6AIbuU22g43EtsjK9coCXffkQABfWqTlz/D+1MXyv52j82dMADF64gour9Rpnfk1jI/j0pc8XZIr5DjjpUM0liu7jxeeMq5t53M10anE05oBXAp9yzl0HTKCmwgxOY6gD9VYRuU1EtovI9ikW7w/fMNJGLZrCYeCwc+5h7/FdqFA4JiJDzrmjIjIEBIpL59w2YBto7kMN45iXMP6I+cpbVRJwFBQXH7YhbjlqKTEWdO1ytu1MOTZPYwAtkApwwfcpjI7T/1N1qD39v3R+rnz/I7DmZQCcG/DSnT0/woE35xh+QIOWcqe8FXoqz7TnB2g9pBpIfnhgRkNwLfqVnNis52w7NYmc1/s4Pqx+iaEfTnB+WDMic31aJXq64JCCXvfchB7vF13h5OlAR+DMvQ3ZwyIMQeeMemWPOzu4ak3BOTcKHBKRq7ynbgSeAu4BtnrPbQW+UdMIDcNIlFp3H34XuNPbedgLvB8VNF8VkVuBA8C7arxG1YTxR8wXWFLJNk7gllbM2ZphQ7krXaWKtYmLG1YB0LZzv7629jJ45Al9cVJ3B06/7wbOrlFfQn6JrtRr79axTXYtZen2A4CWYQOQqfyMPekmVHvIHcvM7CZMe+XVLlx3AwCdP9qHu3wIgMF/0xwI99IEB3/vSgBG/lnPkR07zcTVuhW5dkh9Fmev0cedd10qvhI2LybScmzeuebLtExbrk5NQsE59zgQlIpZWx50EXFPWKazM5Jz15r2GtU4ZhP2yx1UpzBzQn9w+SvVfGg5MIYfS3f9pucBOPW5VbSO+ynNaj48+5vquNv4Z4cvmR5PqOOQrk6m2/Vrl/UiFQsvjJLpUnNAXqXVnPu/9pie863X0POYF4eR13iFi9eMUNDASjKHVABMXbWaA/9VTZW2H2kcxEBmbu3DoDmuNjch09ExZ9u43PfATc2NREwyByMsFtFoGEYJqch9kFyO7LLlgVs4catUUZ2/VnMh7Dhq0Zz8DMqsV18xf3R0ZpUsNhv8+P18z5KS97/wjhGW79BtxDtHvgDAW6ffR/dDaiLItJZhu9inX6uLawZpfUi3DP3tTTcOeG3n/TjQbF8fbpVuN2aP6qp5cctGAHLnpxl9o5oPyx9WrWd8uJWBTZ4T1htr9rFn2fAXqpWcukav1fuIpie7wcGyTttqcxOCgsvKfg8CIl/TpiWAaQqGYcwiFZqCy+cpHDtOtrcnlu2WsPUDytmWlWbNVcPsAJsg+3QhDaGcY9HPoCzuwxj0Wf3r585oENDEWh3H0F17OPKr6wBYd+9t+n97noN/q9pD+wNeZNMGddKO71lK7w/0XLJRg53cjl2XxrpRnYW8cGwmCOnk+9TBWPCiopf/cIzcOa/0m1eA5dxK4cIunfve9br9mDlzjmf+h96jkXtUe3Av6Vw1QyexqL9r5UiFUPCJa/81rIpWTo2sNEFmIbLLBkoeF148MUcdLaeKzhcHEekcenkILeOe2pvPk/WiFVuPqop+dm0LF715a2nzIhp3aAzDkhenmPgv2lKu+z790ReKcjCKayr6wqx7rwqijCcA5KVznFupQqf3STVTevb10uX5LTNeSrZkMvQ9qePt/t+aRzH2SRVgS7/W+EIhybZ4Zj4YhlFCqjSFxUStKm1UcRBlTavnNeegJasOROnpnqmJeOZKLy/i7DTdD6lDsvuAbrld/C0915Jv5ZCjXqSipyFkrtkAXsk1XzOT616B26NLf86r/Xj6FZrH0Hu+h5MbdO1qP+k1gHl+nDNXejkGrV75ufZWUEWFJx/RSMYrf6bXjiexvXKyAQ7PsCZz1CXdyl4r9isYhtFQmKYQAVHkOYS+lp/NePHiTG5Hpfn6xU7Tsv4Wr3185iWNwsvv3c/kdZr0Ovx9fW3p40dY+kP1Axz/ZY14X/JZ9ZdMrsjTNqrL98Xr1anYvmMvLFHNInu5RkzK0Rd56Rc3AND5Qy3e0ndBnYWSL3DFZ7y59bY1n/7QCtb8c6kzcXLdctrOqDYy9GPPb+Flb1ZCnL00gvwC5bSE4uCoJDSEmesmdiXDMBqChtEUogoHjaM0VpJdqUrGXeVqFvaz+9ufubNafj03cjld39Hch8ygagPfeuRbvOV17wRgXBMbWX6P+gye+egaXn5QdxVa7t+hL3Z3w7BWaCp0e71BO9vp2KdzKN4uxAWvNkJuYmpmPC9erYFb/T+7FDYtXv/Iqc4cZ9boGjfyFQ1ayntBUsVkr7xCr/3s8zPbfDjVegovnpipreDPrf99kfa2kq3cOJid1Ztk569iGkYoRBX5FUdprKjMh7iLZ1TL+Z/TSMElu16Y+aLuf/+1AKy9+7+zYUp/hK2nVV0/+UZ19A0+KjzzOxqp+PK/VZV+z60rWfdP6mQ99Eb9QbedYibtecX/06Sng7+tpsWVHz/Cc7+rDkbnfVvXf24M6dQfrzt5GoAL/cO0+tNWmN+1WHj2+Ut/B6nzsxzAYb8vs82OTFdXxcVb0lJQyMwHwzBKaBhNoRL8wKCkItmiMh/qoSEERmrO0lhavrcdgJPv2ULf/arOd+/Vlb19h+OZD+mqPvKvntrbomvNku176RjzCp14RVo7v3apEvPI3Zfuz+Gb9J6NvVsjH3vU30hh1TK61RqhZ6/X0+LEKViqpgQrNLBp6ZFJWs56EZsHDs37ecMWAq40x2S2qj89Ph5YvKURME3BMIwSmlJTaIZY90oot422UN5HYPj2PBpL60vTM3b4wLfUbh9/3XqmW9VRl1+iuQ9LH9Mw49FfvpKV92sN38KHVRMYemmMs9epo3F8WI/v2z3Jiu1eePO/aR0F3yH49P8cYPV39Vptjz7nDaSF06/SzMmTG/Qc062Oy+/ztlADR68spCEkmWOQVsRV0w8gYrql310vN1acEJXt66NwxlPdyzRkqWXHIcnmsI2AbFb1PnPaU6vbWjk/rHOUnfTqMY57anxXKy+t0ojD49fr96zviQyDO/Se+e3lCrt2k/PqPB56p5oiPfv0fnYePkdmv3r9pe1S9OKRv9SdixV/oebA1NIcrfdur+ozhU2YqydROKHvd3ftcM4FFUUqwcwHwzBKSJX5ECQFg9KHK47kc3PLcoXFNIRSXnqZOuB6Tui85Hftpl1ern/36uo9eoPXtenYNF37vUg8p6+1n8zz0ohuRXa8oK9lr93I2bWqbSzbqep9++P79X39vTOqfHaD9oY4ePMg2Qe98Qx7kZWHzlf8WZJ2SAeVbwtLkk5o0xQMwyghVT6FcsRVgCXT1VWRNpDGQptxE7hteZXWKpjuap8poeaWePa91w1qYlUb+XYNaFr2iLcaH3sR6fG0vwHVDlxWyOzSfUc/4OfiJi2+2vofu5j8+VfoW1/laYjtsOaLnp/BK+ZaeGG0ouCfoF6cUXzH/JJ3fkGbNOBr2/ee+Xwon0KqzIdyVHOzJKcfz+UvVdGdfdMqNQ/mEwjl9r/D7HlnOjvJ+LUTy+yz++RWrgjVbbr484Z1Vs1RqzNzE4sKXil2tlzN9FmdQ+lRs6DlZxo1OLF5E8P/ohGKk8P62TJL28gd0yhEmdIfdGbvKFPX6G5D6wv6WvveFwE4/7pNHH+lfoalh9VU6BidQgrejsc+LbyS7e2hUIFQmA6Yg8LpM3PM1UodfMXCILd2RMcYEG4dJQs1G640jsbMB8MwSmgY8yFpkt6miss8CiLK9ODs4CDnXjUCQMej+/VJr/ELJ05xeKumU3cfUK0ge9HRPuY5Hx/aCXjazNXqRDxzlZoU3Xt1bC6bIbtTNQ/xGsZMXbP2UjxDwEoe2Ew2xpToIHJDKwMTqOppXtiWpGEYVVGTT0FEPgT8N7Sz9BNo27gh4MvAANqe/tedc+nxuoQkcWfidDiNrViDKdeNqFzQVdjVcrYvJGj1K4yN0bHDaxu3Ttu05XynYWcHq+71nJAtXjeozhayz6gf4PitWrn5wjJhqls//xX/qNuPBa/nhDz8M5wXMCW79X0tO/fPlFgL0q6CPt/s56SlNdbVOn90NFDbTJMDcj6q1hREZBXwe8Bm59wmIAu8G/gY8HHn3DrgFHBrFAM1DCMZat19yAFLRGQK6ACOAq8HftV7/Q7gT4BP1XgdYO7qt5DXNenglFoI6yEuXnXKvSeKoKvZuyXzFRnx6wXkvG5N/rgya1aROeZpCl2qdWRPniXvre7Lv7Zr5njfUz/drbb/8Vfrve7t38ySg2dKzhsFmc4lFE7Ht2pn+/rqunUdNhs0iKqFgnPuiIj8JXAQOA98DzUXTjvn/D3Aw8Cqaq8xm9lf9KAfe3b9WgrP7Z339UalEeLzZ0eYumf2wipNXJpcpbELbQdPwpar9XjP0Zi5diOcUQEkBzSB6rJRvXf50WOxVGMunD4Ta15L1MV8Kv2R11KwpRbzoQ+4GVgDXAZ0AjdV8P7bRGS7iGyfIh0VZwzDqM18eAOwzzk3BiAidwOvAXpFJOdpC8PAkaA3O+e2AdtAtyRrGEcJvpawELW2jq+GYsddUIpuuUCZtGoI2RXBjYFBVys/cCfr/e8GB8me1FW0kFHno+w9TL7K+1DLat9IeS3FK3/cZftq2ZI8CGwRkQ4REeBG4CngQeAW75itwDdqG6JhGElSU/CSiPwp8CtAHngM3Z5chW5J9nvP/Zpzrqx9EGXw0mLMTYiaWpxUEBxebtSfsMFLNe0+OOf+GPjjWU/vBV5dy3lrwQRC7dRaVbicMKglfdgnt3Zkbj5BJlu20E7ocw9pVai4y7lHTZStCyyi0TCMEhomS7KYcttzC8UuVH3NOjgm4yZ0c9MI8waiOEdg1uECWkLY2otRaQjZ3h6mJ7TwS3EUY1yxM1FugZqmYBhGCanQFCSXI7ts/q2t2RROzb+6xRWw1Ewawgy5cLe/Xu3LoiRIQ8it1Ga5YepSVMy0m5PnEJUWG3ekbiqEgsvnQwsEIBKHkk/YG7WgI8fvcBxhKnrcRTqaKeIziIViGCoRBpWmtgctIlHNd9z3zcwHwzBKSIWmEJYwZc2kra2iLbWwUndBR04FGkKmszNUO7K4y3g1ApXW0CzGf1+l34ligjTETLtWpp6+cKHi8+VWa7Pe/KHDVY0nCUxTMAyjhIbSFMKsrmlp512OsE1L00KlzVajpFhLqNbBVst3IkhDrEZD8JmtISRZhi8spikYhlFCajWFWuy2SkhSUjeCPRlElBpCdnCw4uat/i5CM+6WpE1LgBQLhbiFgU+SN6UWYdAsSUbVdHP2TQg/stIVCg1hJlZKpfkLcaVQm/lgGEYJqdUU0kZS5sx81ENDCJsvUGuqdViaIbIyCF8DqjR/IY1FVgzDaEJMUwhJ1BpCPbf5ylEcWBXW/k+DfZ/t7o622nOCHaXSpgE1pVDIrlgOEJhPkZaqyGkTBj5pHddCRJ2wlrYfapKY+WAedSMnAAAI20lEQVQYRgnp0BREaopPn81sDaHYYVZvDSFufIeotGoj0zSmfKdFWzOCMU3BMIwS0qEpOBers6rSgJlsX1/kHX6qoRpn14xDtE5bp2FoJg2h3lvVcZAOoZAy0iAQYHE7uxqFZhIGPmY+GIZRggmFRUimq2smycgIiV9ubxFgQsEwjBIWFAoi8nkROS4iTxY91y8i94nIc97/fd7zIiJ/IyJ7RGSniLwyzsE3K9nubrLd3eRWXUZu1WXzH9fbM5MpVwnT4+MN1Vw1LP68xUKEBXnTThhN4QvMbTF/O/CAc2498ID3GODNwHrv323Ap6IZpmEYSbHg7oNz7t9FZGTW0zcDv+j9fQfwA+APvef/0WnX2odEpFdEhpxzR6Ma8GJgJuBogcCjNBboqCezA7XK1RtIcyPiuFvNL0S1W5Irin7oo8AK7+9VwKGi4w57zzWEUIiySadRf8r9qOIWCLVU9Kq3sK/Z0ehpBRUbXCJym4hsF5HtU9Q/y84wDKVaoXBMRIYAvP/9ZIMjwOqi44a95+bgnNvmnNvsnNvcQluVw6gdP2oQVEMwLWFxUM6BGwX1Xu1roVqhcA+w1ft7K/CNouff5+1CbAHOmD/BMBqLMFuSXwJ+AlwlIodF5Fbgz4E3ishzwBu8xwDfBvYCe4DPAL8dy6gjZDGHEse9WqaZ/JEX6j2E1BJm9+E987x0Y8CxDvhArYNqBjLt7aHi4oudm0lXbLYfRvqJu8N0EBbRaBhGCZYlGRNhs+eKHZuN3tPBiJ56NMAxTcEwjBJMKNSJavMWMp2dM5WgDSMOTCgYhlFC6nwKae2HEDVhgluCCpw26ryUK7tvpIvUCYVG/dL7+MVLokhNrkfCTtRNVXxMGFSHnwqeZFVuMx8MwyghdZpCo5PW4iVh+2oErUj1zh6tdypxPalH3w7TFAzDKCF1mkLcDqnFuurU0lej3pmji+1e1ZvUCYUohEE5dbeZv2CZjo6mS/DKDg5W3MzHqA0zHwzDKCF1mkIU1FvdrRfNpiVA5S3/jLnM9PgI6bM0TcEwjBKaUiikvQOS7/MwjCSotM9HU5oPaY0VmKFQqPcIDGNemlJTMAyjekwo1EC2r68qU6AeUWqGERYTCoZhlNCUPoXEyCye9uTG4sE0BcMwSmhqTSHugi1pbVBqGLXQ1EKh0Qu2GEY9MPPBMIwSwrSN+7yIHBeRJ4ue+wsReUZEdorIP4tIb9FrHxGRPSKyW0TeFNfADcOIhzCawheAm2Y9dx+wyTl3NfAs8BEAEdkIvBt4hfeevxeRbGSjNQwjdhYUCs65fwdOznrue845v53RQ2jLeYCbgS875y465/ahjWZfHeF4mxa/crNh1JsofAq/CXzH+3sVcKjotcPecw1HtdGK1WI7GUZaqGn3QUQ+CuSBO6t4723AbQDtdNQyDMMwIqRqoSAivwG8DbjRa0EPcARYXXTYsPfcHJxz24BtAN3S74KOqSeLtVCLYVRlPojITcCHgbc754rL/dwDvFtE2kRkDbAeeKT2YRqGkRRhtiS/BPwEuEpEDovIrcAngS7gPhF5XEQ+DeCc2wV8FXgK+C7wAedcRcUD4rTls8sGYjmvYTQTcknzrx/d0u+ulxvrPQxjAeJqKWckw/3urh3Ouc0LHWcRjYZhlGBCwQiNaQmLAxMKhmGUYELBMFKC5HJIrv6JyyYUDMMoof5iyTAMAFw+v/BBCWCaQgPgd+I2jCQwoWAYRgmpCF4SkTFgAnix3mMBlmHjKMbGUUojj+NlzrnBhQ5KhVAAEJHtYaKtbBw2DhtHvOMw88EwjBJMKBiGUUKahMK2eg/Aw8ZRio2jlKYfR2p8CoZhpIM0aQqGYaSAVAgFEbnJ6xOxR0RuT+iaq0XkQRF5SkR2icgHvef7ReQ+EXnO+z+R6q0ikhWRx0Tkm97jNSLysDcnXxGR1gTG0Csid3k9PZ4WkRvqMR8i8iHvnjwpIl8Skfak5mOePieBcyDK33hj2ikir4x5HIn0W6m7UPD6Qvwd8GZgI/Aer39E3OSBP3DObQS2AB/wrns78IBzbj3wgPc4CT4IPF30+GPAx51z64BTwK0JjOETwHedcy8HrvHGk+h8iMgq4PeAzc65TUAW7SWS1Hx8gbl9TuabgzejJQfXo0WIPxXzOJLpt+Kcq+s/4Abg3qLHHwE+UodxfAN4I7AbGPKeGwJ2J3DtYfTL9nrgm4CggSm5oDmKaQw9wD48P1PR84nOB5faBPSjuTnfBN6U5HwAI8CTC80B8H+B9wQdF8c4Zr32TuBO7++S3wxwL3BDtdetu6ZACnpFiMgIcB3wMLDCOXfUe2kUWJHAEP4aLYQ77T0eAE67Sw13kpiTNcAY8A+eGfNZEekk4flwzh0B/hI4CBwFzgA7SH4+iplvDur53Y2t30oahEJdEZGlwNeB33fOlZQWcip2Y92eEZG3AcedczvivE4IcsArgU85565Dw85LTIWE5qMP7TS2BrgM6GSuGl03kpiDhail30oY0iAUQveKiBoRaUEFwp3Oubu9p4+JyJD3+hBwPOZhvAZ4u4jsB76MmhCfAHpFxE9tT2JODgOHnXMPe4/vQoVE0vPxBmCfc27MOTcF3I3OUdLzUcx8c5D4d7eo38p7PQEV+TjSIBQeBdZ73uVW1GFyT9wXFREBPgc87Zz7q6KX7gG2en9vRX0NseGc+4hzbtg5N4J+9u87594LPAjckuA4RoFDInKV99SNaKn+ROcDNRu2iEiHd4/8cSQ6H7OYbw7uAd7n7UJsAc4UmRmRk1i/lTidRhU4VN6CelOfBz6a0DVfi6qBO4HHvX9vQe35B4DngPuB/gTn4ReBb3p/r/Vu7B7ga0BbAte/Ftjuzcm/AH31mA/gT4FngCeBfwLakpoP4EuoL2MK1Z5unW8OUIfw33nf2yfQHZM4x7EH9R3439dPFx3/UW8cu4E313Jti2g0DKOENJgPhmGkCBMKhmGUYELBMIwSTCgYhlGCCQXDMEowoWAYRgkmFAzDKMGEgmEYJfx/7wPcf/jvvCIAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Access index 5\n",
+    "ENTRY=5\n",
+    "data,label,idx = ds[ENTRY]\n",
+    "\n",
+    "# Data shape\n",
+    "print('Entry',ENTRY,'... label:',label,'... data shape:',data.shape)\n",
+    "\n",
+    "# Visualize\n",
+    "plt.imshow(data[:,:,0])\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## DataLoader\n",
+    "Given a `Dataset` instance, `DataLoader` provides handy features for streaming data including randomization of samples, multi-threaded data read/process (e.g. `transform` function in `Dataset`), etc.. \n",
+    "\n",
+    "The `DataLoader` is for ML training where we typically access data by a chunk, called _batch_ (or sometimes _mini batch_). The number of samples (e.g. events) in each batch is called _batch size_ (or _mini batch size_). When preparing a batch, `DataLoader` combines (or collates) N events where N is the batch size. You need to provide a function to perform this collation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def HKCollate(batch):\n",
+    "    data  = np.vstack([sample[0] for sample in batch])\n",
+    "    label = [sample[1] for sample in batch]\n",
+    "    idx   = [sample[2] for sample in batch]\n",
+    "    return data,label,idx"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now we can define the dataloader."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "loader = DataLoader(ds,\n",
+    "                    batch_size=5, # set the batch size = 50\n",
+    "                    shuffle=True,  # enable randomization of samples in a batch\n",
+    "                    num_workers=1, # number of workers to parallelize data streaming\n",
+    "                    collate_fn=HKCollate # collation method\n",
+    "                   )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here's how you can loop over 10 batch samples"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def loop(loader,loop_limit=3):\n",
+    "\n",
+    "    # Let's measure time that takes in each loop\n",
+    "    trecord = np.zeros([loop_limit],dtype=np.float32)\n",
+    "    t = time.time()\n",
+    "    for iteration, batch in enumerate(loader):\n",
+    "\n",
+    "        data,label,index = batch\n",
+    "\n",
+    "        # Print out some content info\n",
+    "        print('Iteration',iteration,'... time:',time.time()-t,'[s]')\n",
+    "        print('    Labels:',label)\n",
+    "        print('    Index :',index,'\\n')\n",
+    "        trecord[iteration] = time.time() - t\n",
+    "        t = time.time()\n",
+    "\n",
+    "        # break when reaching the loop limit\n",
+    "        if (iteration+1) == loop_limit:\n",
+    "            break\n",
+    "    return trecord"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's try running data loader for 5 events"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Iteration 0 ... time: 6.0243601799 [s]\n",
+      "    Labels: [2, 1, 2, 2, 1]\n",
+      "    Index : [9929, 23361, 13852, 11487, 24578] \n",
+      "\n",
+      "Iteration 1 ... time: 5.70613002777 [s]\n",
+      "    Labels: [2, 1, 1, 2, 2]\n",
+      "    Index : [5811, 18119, 23952, 709, 14916] \n",
+      "\n",
+      "Iteration 2 ... time: 5.89799404144 [s]\n",
+      "    Labels: [2, 2, 2, 1, 1]\n",
+      "    Index : [8966, 5611, 13569, 22054, 16316] \n",
+      "\n",
+      "Iteration 3 ... time: 5.2024679184 [s]\n",
+      "    Labels: [2, 1, 1, 1, 1]\n",
+      "    Index : [6612, 23651, 21302, 18721, 22733] \n",
+      "\n",
+      "Iteration 4 ... time: 6.37095189095 [s]\n",
+      "    Labels: [2, 2, 2, 2, 2]\n",
+      "    Index : [606, 14386, 15103, 11438, 10649] \n",
+      "\n",
+      "Overall average iteration time: 5.841918 [s]\n",
+      "First event     iteration time: 6.0267143 [s]\n",
+      "After first event average time: 5.7957187 [s]\n"
+     ]
+    }
+   ],
+   "source": [
+    "time_record = loop(loader,5)\n",
+    "print('Overall average iteration time:',time_record.mean(),'[s]')\n",
+    "print('First event     iteration time:',time_record[0],    '[s]')\n",
+    "print('After first event average time:',time_record[1:].mean(),'[s]')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "... that was SO SLOW! I hope our impatient team member has not yet thrown his/her laptop yet ;) This slow speed is due to the fact that, for each event, we are performing file open & close. This is very inefficient.\n",
+    "\n",
+    "## _Faster_ data streaming\n",
+    "\n",
+    "There are three possible solutions to an issue of slow data streaming. \n",
+    "0. read ALL data in the RAM upfront (e.g. creation of `Dataset`)\n",
+    "1. increase number of _workers_ to read data (i.e. parallelization)\n",
+    "2. combination of 0 and 1: employ parallelization while utilizing some data cache in RAM\n",
+    "\n",
+    "The first and last methods are bounded by the size of RAM memory availability. Here, we try the option 1. This can be done by specifying _num workers_ argument value at the construction of `DataLoader`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Iteration 0 ... time: 7.8519949913 [s]\n",
+      "    Labels: [2, 2, 1, 1, 2]\n",
+      "    Index : [4753, 15021, 18908, 21195, 6830] \n",
+      "\n",
+      "Iteration 1 ... time: 0.809750080109 [s]\n",
+      "    Labels: [1, 2, 2, 2, 2]\n",
+      "    Index : [16615, 12437, 4140, 14899, 14000] \n",
+      "\n",
+      "Iteration 2 ... time: 0.000488042831421 [s]\n",
+      "    Labels: [2, 2, 2, 1, 2]\n",
+      "    Index : [8951, 3691, 13423, 20795, 2859] \n",
+      "\n",
+      "Iteration 3 ... time: 5.10215759277e-05 [s]\n",
+      "    Labels: [2, 1, 2, 2, 2]\n",
+      "    Index : [4246, 24115, 8945, 12991, 12054] \n",
+      "\n",
+      "Iteration 4 ... time: 4.6968460083e-05 [s]\n",
+      "    Labels: [2, 1, 1, 2, 2]\n",
+      "    Index : [12918, 17537, 23444, 1387, 11583] \n",
+      "\n",
+      "Iteration 5 ... time: 0.00012993812561 [s]\n",
+      "    Labels: [2, 1, 2, 2, 1]\n",
+      "    Index : [10357, 19752, 8765, 11220, 18703] \n",
+      "\n",
+      "Iteration 6 ... time: 0.0913889408112 [s]\n",
+      "    Labels: [2, 2, 2, 1, 2]\n",
+      "    Index : [8100, 9157, 14194, 22520, 9166] \n",
+      "\n",
+      "Iteration 7 ... time: 3.60012054443e-05 [s]\n",
+      "    Labels: [1, 2, 1, 1, 2]\n",
+      "    Index : [17865, 10158, 24577, 22101, 1558] \n",
+      "\n",
+      "Iteration 8 ... time: 9.51290130615e-05 [s]\n",
+      "    Labels: [1, 1, 1, 1, 2]\n",
+      "    Index : [21176, 23232, 20694, 20400, 5414] \n",
+      "\n",
+      "Iteration 9 ... time: 5.10215759277e-05 [s]\n",
+      "    Labels: [1, 2, 2, 1, 1]\n",
+      "    Index : [18835, 13666, 13127, 24657, 17760] \n",
+      "\n",
+      "Overall average iteration time: 0.87667865 [s]\n",
+      "First event     iteration time: 7.85535 [s]\n",
+      "After first event average time: 0.101270676 [s]\n"
+     ]
+    }
+   ],
+   "source": [
+    "loader = DataLoader(ds,\n",
+    "                    batch_size=5, # set the batch size = 50\n",
+    "                    shuffle=True,  # enable randomization of samples in a batch\n",
+    "                    num_workers=20, # number of workers to parallelize data streaming\n",
+    "                    collate_fn=HKCollate # collation method\n",
+    "                   )\n",
+    "time_record = loop(loader,10)\n",
+    "print('Overall average iteration time:',time_record.mean(),'[s]')\n",
+    "print('First event     iteration time:',time_record[0],    '[s]')\n",
+    "print('After first event average time:',time_record[1:].mean(),'[s]')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The first event takes some time. This is because all workers are initiated and nothing is read yet. However, while 5 workers are reading 5 events to form the first batch, 15 other workers are reading data in parallel and store in a buffer. From the second event and onwards, data in a buffer is loaded (i.e. faster data streaming). At some point, parllel workers and data query will balance out and the speed reaches an equilibrium. You have a good solution when the data streaming speed at the equilibrium is much smaller than the time it takes to consume data, which is an algorithm training step to consume 1 batch of data.\n",
+    "\n",
+    "If you have questions/suggestions/concerns, [contact me](mailto:kterao@slac.stanford.edu)!"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/MNIST LeNet.ipynb
+++ b/MNIST LeNet.ipynb
@@ -1,0 +1,360 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# CNN on MNIST\n",
+    "\n",
+    "In this notebook, we train one of oldest CNNs, called [_LeNet_](http://yann.lecun.com/exdb/publis/pdf/lecun-01a.pdf), to classify hand-written digits from 0 to 9. The dataset is public and called [_MNIST_](http://yann.lecun.com/exdb/mnist/). MNIST is widely used for an introductory machine learning (ML) courses/lectures, and not limited to CNN. LeNet is one of the very first CNN application and nearly 2 decades old, and first applied on MNIST.\n",
+    "\n",
+    "First we go over MNIST data set, LeNet construction, and finally training."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from __future__ import print_function\n",
+    "import torch\n",
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## MNIST data set\n",
+    "Most, if not all, ML libraries provide an easy way (API) to access MNIST dataset. This is true in `pytorch` as well. MNIST dataset in `Dataset` instance is available from `torchvision`. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "60000 images prepared!\n"
+     ]
+    }
+   ],
+   "source": [
+    "from torchvision import datasets, transforms\n",
+    "\n",
+    "LOCAL_DATA_DIR = './data' # this is where data files are downloaded\n",
+    "\n",
+    "dataset = datasets.MNIST(LOCAL_DATA_DIR, train=True, download=True,\n",
+    "                         transform=transforms.Compose([transforms.ToTensor()]))\n",
+    "print(len(dataset),'images prepared!')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's visualize data with a label."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Label: 5\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAP8AAAD8CAYAAAC4nHJkAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMi40LCBodHRwOi8vbWF0cGxvdGxpYi5vcmcv7US4rQAADoBJREFUeJzt3X2MXOV1x/HfyXq9jo1JvHHYboiLHeMEiGlMOjIgLKCiuA5CMiiKiRVFDiFxmuCktK4EdavGrWjlVgmRQynS0ri2I95CAsJ/0CR0FUGiwpbFMeYtvJlNY7PsYjZgQ4i9Xp/+sdfRBnaeWc/cmTu75/uRVjtzz71zj6792zszz8x9zN0FIJ53Fd0AgGIQfiAowg8ERfiBoAg/EBThB4Ii/EBQhB8IivADQU1r5M6mW5vP0KxG7hII5bd6U4f9kE1k3ZrCb2YrJG2W1CLpP9x9U2r9GZqls+2iWnYJIKHHuye8btVP+82sRdJNkj4h6QxJq83sjGofD0Bj1fKaf6mk5919j7sflnSHpJX5tAWg3moJ/8mSfjXm/t5s2e8xs7Vm1mtmvcM6VMPuAOSp7u/2u3uXu5fcvdSqtnrvDsAE1RL+fZLmjbn/wWwZgEmglvA/ImmRmS0ws+mSPi1pRz5tAai3qof63P2Ima2T9CONDvVtcfcnc+sMQF3VNM7v7vdJui+nXgA0EB/vBYIi/EBQhB8IivADQRF+ICjCDwRF+IGgCD8QFOEHgiL8QFCEHwiK8ANBEX4gKMIPBEX4gaAIPxAU4QeCIvxAUIQfCIrwA0ERfiAowg8ERfiBoAg/EBThB4Ii/EBQhB8IivADQRF+IKiaZuk1sz5JByWNSDri7qU8mkJ+bFr6n7jl/XPruv9n/np+2drIzKPJbU9ZOJisz/yKJesv3zC9bG1n6c7ktvtH3kzWz75rfbJ+6l89nKw3g5rCn/kTd9+fw+MAaCCe9gNB1Rp+l/RjM3vUzNbm0RCAxqj1af8yd99nZidJut/MfuHuD45dIfujsFaSZmhmjbsDkJeazvzuvi/7PSjpHklLx1mny91L7l5qVVstuwOQo6rDb2azzGz2sduSlkt6Iq/GANRXLU/7OyTdY2bHHuc2d/9hLl0BqLuqw+/ueyR9LMdepqyW0xcl697Wmqy/dMF7k/W3zik/Jt3+nvR49U8/lh7vLtJ//WZ2sv4v/7YiWe8587aytReH30puu2ng4mT9Az/1ZH0yYKgPCIrwA0ERfiAowg8ERfiBoAg/EFQe3+oLb+TCjyfrN2y9KVn/cGv5r55OZcM+kqz//Y2fS9anvZkebjv3rnVla7P3HUlu27Y/PRQ4s7cnWZ8MOPMDQRF+ICjCDwRF+IGgCD8QFOEHgiL8QFCM8+eg7ZmXkvVHfzsvWf9w60Ce7eRqff85yfqeN9KX/t668Ptla68fTY/Td3z7f5L1epr8X9itjDM/EBThB4Ii/EBQhB8IivADQRF+ICjCDwRl7o0b0TzR2v1su6hh+2sWQ1eem6wfWJG+vHbL7hOS9ce+cuNx93TM9fv/KFl/5IL0OP7Ia68n635u+au7930tuakWrH4svQLeoce7dcCH0nOXZzjzA0ERfiAowg8ERfiBoAg/EBThB4Ii/EBQFcf5zWyLpEslDbr74mxZu6Q7Jc2X1Cdplbv/utLOoo7zV9Iy933J+sirQ8n6i7eVH6t/8vwtyW2X/vNXk/WTbiruO/U4fnmP82+V9PaJ0K+T1O3uiyR1Z/cBTCIVw+/uD0p6+6lnpaRt2e1tki7LuS8AdVbta/4Od+/Pbr8sqSOnfgA0SM1v+PnomwZl3zgws7Vm1mtmvcM6VOvuAOSk2vAPmFmnJGW/B8ut6O5d7l5y91Kr2qrcHYC8VRv+HZLWZLfXSLo3n3YANErF8JvZ7ZIekvQRM9trZldJ2iTpYjN7TtKfZvcBTCIVr9vv7qvLlBiwz8nI/ldr2n74wPSqt/3oZ55K1l+5uSX9AEdHqt43isUn/ICgCD8QFOEHgiL8QFCEHwiK8ANBMUX3FHD6tc+WrV15ZnpE9j9P6U7WL/jU1cn67DsfTtbRvDjzA0ERfiAowg8ERfiBoAg/EBThB4Ii/EBQjPNPAalpsl/98unJbf9vx1vJ+nXXb0/W/2bV5cm6//w9ZWvz/umh5LZq4PTxEXHmB4Ii/EBQhB8IivADQRF+ICjCDwRF+IGgKk7RnSem6G4+Q58/N1m/9evfSNYXTJtR9b4/un1dsr7olv5k/cievqr3PVXlPUU3gCmI8ANBEX4gKMIPBEX4gaAIPxAU4QeCqjjOb2ZbJF0qadDdF2fLNkr6oqRXstU2uPt9lXbGOP/k4+ctSdZP3LQ3Wb/9Qz+qet+n/eQLyfpH/qH8dQwkaeS5PVXve7LKe5x/q6QV4yz/lrsvyX4qBh9Ac6kYfnd/UNJQA3oB0EC1vOZfZ2a7zWyLmc3JrSMADVFt+G+WtFDSEkn9kr5ZbkUzW2tmvWbWO6xDVe4OQN6qCr+7D7j7iLsflXSLpKWJdbvcveTupVa1VdsngJxVFX4z6xxz93JJT+TTDoBGqXjpbjO7XdKFkuaa2V5JX5d0oZktkeSS+iR9qY49AqgDvs+PmrR0nJSsv3TFqWVrPdduTm77rgpPTD/z4vJk/fVlrybrUxHf5wdQEeEHgiL8QFCEHwiK8ANBEX4gKIb6UJjv7U1P0T3Tpifrv/HDyfqlX72m/GPf05PcdrJiqA9ARYQfCIrwA0ERfiAowg8ERfiBoAg/EFTF7/MjtqPL0pfufuFT6Sm6Fy/pK1urNI5fyY1DZyXrM+/trenxpzrO/EBQhB8IivADQRF+ICjCDwRF+IGgCD8QFOP8U5yVFifrz34tPdZ+y3nbkvXzZ6S/U1+LQz6crD88tCD9AEf7c+xm6uHMDwRF+IGgCD8QFOEHgiL8QFCEHwiK8ANBVRznN7N5krZL6pDkkrrcfbOZtUu6U9J8SX2SVrn7r+vXalzTFpySrL9w5QfK1jZecUdy20+esL+qnvKwYaCUrD+w+Zxkfc629HX/kTaRM/8RSevd/QxJ50i62szOkHSdpG53XySpO7sPYJKoGH5373f3ndntg5KelnSypJWSjn38a5uky+rVJID8HddrfjObL+ksST2SOtz92OcnX9boywIAk8SEw29mJ0j6gaRr3P3A2JqPTvg37qR/ZrbWzHrNrHdYh2pqFkB+JhR+M2vVaPBvdfe7s8UDZtaZ1TslDY63rbt3uXvJ3UutasujZwA5qBh+MzNJ35H0tLvfMKa0Q9Ka7PYaSffm3x6AepnIV3rPk/RZSY+b2a5s2QZJmyR9z8yukvRLSavq0+LkN23+Hybrr/9xZ7J+xT/+MFn/8/fenazX0/r+9HDcQ/9efjivfev/Jredc5ShvHqqGH53/5mkcvN9X5RvOwAahU/4AUERfiAowg8ERfiBoAg/EBThB4Li0t0TNK3zD8rWhrbMSm775QUPJOurZw9U1VMe1u1blqzvvDk9Rffc7z+RrLcfZKy+WXHmB4Ii/EBQhB8IivADQRF+ICjCDwRF+IGgwozzH/6z9GWiD//lULK+4dT7ytaWv/vNqnrKy8DIW2Vr5+9Yn9z2tL/7RbLe/lp6nP5osopmxpkfCIrwA0ERfiAowg8ERfiBoAg/EBThB4IKM87fd1n679yzZ95Vt33f9NrCZH3zA8uTdRspd+X0Uadd/2LZ2qKBnuS2I8kqpjLO/EBQhB8IivADQRF+ICjCDwRF+IGgCD8QlLl7egWzeZK2S+qQ5JK63H2zmW2U9EVJr2SrbnD38l96l3SitfvZxqzeQL30eLcO+FD6gyGZiXzI54ik9e6+08xmS3rUzO7Pat9y929U2yiA4lQMv7v3S+rPbh80s6clnVzvxgDU13G95jez+ZLOknTsM6PrzGy3mW0xszlltllrZr1m1jusQzU1CyA/Ew6/mZ0g6QeSrnH3A5JulrRQ0hKNPjP45njbuXuXu5fcvdSqthxaBpCHCYXfzFo1Gvxb3f1uSXL3AXcfcfejkm6RtLR+bQLIW8Xwm5lJ+o6kp939hjHLO8esdrmk9HStAJrKRN7tP0/SZyU9bma7smUbJK02syUaHf7rk/SlunQIoC4m8m7/zySNN26YHNMH0Nz4hB8QFOEHgiL8QFCEHwiK8ANBEX4gKMIPBEX4gaAIPxAU4QeCIvxAUIQfCIrwA0ERfiCoipfuznVnZq9I+uWYRXMl7W9YA8enWXtr1r4keqtWnr2d4u7vn8iKDQ3/O3Zu1uvupcIaSGjW3pq1L4neqlVUbzztB4Ii/EBQRYe/q+D9pzRrb83al0Rv1Sqkt0Jf8wMoTtFnfgAFKST8ZrbCzJ4xs+fN7LoieijHzPrM7HEz22VmvQX3ssXMBs3siTHL2s3sfjN7Lvs97jRpBfW20cz2Zcdul5ldUlBv88zsJ2b2lJk9aWZ/kS0v9Ngl+irkuDX8ab+ZtUh6VtLFkvZKekTSand/qqGNlGFmfZJK7l74mLCZnS/pDUnb3X1xtuxfJQ25+6bsD+ccd7+2SXrbKOmNomduziaU6Rw7s7SkyyR9TgUeu0Rfq1TAcSvizL9U0vPuvsfdD0u6Q9LKAvpoeu7+oKShty1eKWlbdnubRv/zNFyZ3pqCu/e7+87s9kFJx2aWLvTYJfoqRBHhP1nSr8bc36vmmvLbJf3YzB41s7VFNzOOjmzadEl6WVJHkc2Mo+LMzY30tpmlm+bYVTPjdd54w++dlrn7xyV9QtLV2dPbpuSjr9maabhmQjM3N8o4M0v/TpHHrtoZr/NWRPj3SZo35v4Hs2VNwd33Zb8HJd2j5pt9eODYJKnZ78GC+/mdZpq5ebyZpdUEx66ZZrwuIvyPSFpkZgvMbLqkT0vaUUAf72Bms7I3YmRmsyQtV/PNPrxD0prs9hpJ9xbYy+9plpmby80srYKPXdPNeO3uDf+RdIlG3/F/QdLfFtFDmb4+JOmx7OfJonuTdLtGnwYOa/S9kaskvU9St6TnJP23pPYm6u27kh6XtFujQessqLdlGn1Kv1vSruznkqKPXaKvQo4bn/ADguINPyAowg8ERfiBoAg/EBThB4Ii/EBQhB8IivADQf0/sEWOix6VKakAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "%matplotlib inline\n",
+    "# Print label\n",
+    "print('Label:',dataset[0][1])\n",
+    "# Draw data\n",
+    "plt.imshow(dataset[0][0].view([28,28]))\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Next, let's crate `DataLoader` for training. If you have not learned what `DataLoader` is, [read this notebook](https://github.com/watchmal/ExampleNotebooks/blob/master/HKML%20DataLoader.ipynb)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "train_loader = torch.utils.data.DataLoader(dataset,batch_size=20,shuffle=True,num_workers=1,pin_memory=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Defining a network\n",
+    "In `pytorch`, a network is defined as a `torch.Module` inherited class. All `torch.Module` have two functions: _forward_ and _backward_. The forward function runs data through the CNN and makes a prediction. The backward propagates gradient, computed based on the error from the forward function call, to train the network. \n",
+    "\n",
+    "LeNet has 2 convolution layers, each followed by rectified linear unit (ReLU) and max-pooling, for feature extractions. Then the extracted features run through two hidden layers multi-layer perceptron (MLP) at the end for classifying the input image data into digits (0 to 9)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class LeNet(torch.nn.Module):\n",
+    "    def __init__(self):\n",
+    "        \n",
+    "        super(LeNet, self).__init__()\n",
+    "        # feature extractor CNN\n",
+    "        self._feature_extractor = torch.nn.Sequential(\n",
+    "            torch.nn.Conv2d(1,6,5),\n",
+    "            torch.nn.ReLU(),\n",
+    "            torch.nn.MaxPool2d(2,2),\n",
+    "            torch.nn.Conv2d(6,16,5),\n",
+    "            torch.nn.ReLU(),\n",
+    "            torch.nn.MaxPool2d(2,2) )\n",
+    "        # classifier MLP\n",
+    "        self._classifier = torch.nn.Sequential(\n",
+    "            torch.nn.Linear(256,120),\n",
+    "            torch.nn.ReLU(),\n",
+    "            torch.nn.Linear(120,84),\n",
+    "            torch.nn.ReLU(),\n",
+    "            torch.nn.Linear(84,10) )\n",
+    "\n",
+    "    def forward(self, x):\n",
+    "        # extract features\n",
+    "        features = self._feature_extractor(x)\n",
+    "        # flatten the 3d tensor (2d space x channels = features)\n",
+    "        features = features.view(-1, np.prod(features.size()[1:]))\n",
+    "        # classify and return\n",
+    "        return self._classifier(features)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Defining a train loop\n",
+    "For convenience, define a _BLOB_ class to keep objects together. To a BLOB instance, we attach LeNet, our loss function (`nn.CrossEntropyLoss`), and Adam optimizer algorithm. For analysis purpose, we also include `nn.Softmax`. Finally, we attach data and label place holders."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class BLOB:\n",
+    "    pass\n",
+    "blob=BLOB()\n",
+    "blob.net       = LeNet().cuda() # construct Lenet, use GPU\n",
+    "blob.criterion = torch.nn.CrossEntropyLoss() # use softmax loss to define an error\n",
+    "blob.optimizer = torch.optim.Adam(blob.net.parameters()) # use Adam optimizer algorithm\n",
+    "blob.softmax   = torch.nn.Softmax(dim=1) # not for training, but softmax score for each class\n",
+    "blob.data      = None # data for training/analysis\n",
+    "blob.label     = None # label for training/analysis"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We define 2 functions to be called in the training loop: forward and backward. These functions implement the evaluation of the results, error (loss) definition, and propagation of errors (gradients) back to update the network parameters."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def forward(blob,train=True):\n",
+    "    \"\"\"\n",
+    "       Args: blob should have attributes, net, criterion, softmax, data, label\n",
+    "       \n",
+    "       Returns: a dictionary of predicted labels, softmax, loss, and accuracy\n",
+    "    \"\"\"\n",
+    "    with torch.set_grad_enabled(train):\n",
+    "        # Prediction\n",
+    "        data = blob.data.cuda()\n",
+    "        prediction = blob.net(data)\n",
+    "        # Training\n",
+    "        loss,acc=-1,-1\n",
+    "        if blob.label is not None:\n",
+    "            label = blob.label.cuda() #label = torch.stack([ torch.as_tensor(l) for l in np.hstack(label) ])\n",
+    "            label.requires_grad = False\n",
+    "            loss = blob.criterion(prediction,label)\n",
+    "        blob.loss = loss\n",
+    "        \n",
+    "        softmax    = blob.softmax(prediction).cpu().detach().numpy()\n",
+    "        prediction = torch.argmax(prediction,dim=-1)\n",
+    "        accuracy   = (prediction == label).sum().item() / float(prediction.nelement())        \n",
+    "        prediction = prediction.cpu().detach().numpy()\n",
+    "        \n",
+    "        return {'prediction' : prediction,\n",
+    "                'softmax'    : softmax,\n",
+    "                'loss'       : loss,#.cpu().detatch(),\n",
+    "                'accuracy'   : accuracy}\n",
+    "\n",
+    "def backward(blob):\n",
+    "    blob.optimizer.zero_grad()  # Reset gradients accumulation\n",
+    "    blob.loss.backward()\n",
+    "    blob.optimizer.step()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now we are ready for training! Let's write a loop to load data, call forward, and call backward."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Iteration 99 ... Loss tensor(0.5482, device='cuda:0', grad_fn=<NllLossBackward>) ... Accuracy 0.85\n",
+      "Iteration 199 ... Loss tensor(0.1940, device='cuda:0', grad_fn=<NllLossBackward>) ... Accuracy 0.95\n",
+      "Iteration 299 ... Loss tensor(0.1373, device='cuda:0', grad_fn=<NllLossBackward>) ... Accuracy 1.0\n",
+      "Iteration 399 ... Loss tensor(0.6558, device='cuda:0', grad_fn=<NllLossBackward>) ... Accuracy 0.8\n",
+      "Iteration 499 ... Loss tensor(0.3005, device='cuda:0', grad_fn=<NllLossBackward>) ... Accuracy 0.9\n",
+      "Iteration 599 ... Loss tensor(0.1749, device='cuda:0', grad_fn=<NllLossBackward>) ... Accuracy 0.9\n",
+      "Iteration 699 ... Loss tensor(0.1262, device='cuda:0', grad_fn=<NllLossBackward>) ... Accuracy 0.95\n",
+      "Iteration 799 ... Loss tensor(0.0464, device='cuda:0', grad_fn=<NllLossBackward>) ... Accuracy 1.0\n",
+      "Iteration 899 ... Loss tensor(0.0474, device='cuda:0', grad_fn=<NllLossBackward>) ... Accuracy 1.0\n",
+      "Iteration 999 ... Loss tensor(0.1220, device='cuda:0', grad_fn=<NllLossBackward>) ... Accuracy 0.95\n",
+      "Iteration 1099 ... Loss tensor(0.0753, device='cuda:0', grad_fn=<NllLossBackward>) ... Accuracy 1.0\n",
+      "Iteration 1199 ... Loss tensor(0.1738, device='cuda:0', grad_fn=<NllLossBackward>) ... Accuracy 0.95\n",
+      "Iteration 1299 ... Loss tensor(0.0494, device='cuda:0', grad_fn=<NllLossBackward>) ... Accuracy 1.0\n",
+      "Iteration 1399 ... Loss tensor(0.1088, device='cuda:0', grad_fn=<NllLossBackward>) ... Accuracy 0.95\n",
+      "Iteration 1499 ... Loss tensor(0.0459, device='cuda:0', grad_fn=<NllLossBackward>) ... Accuracy 1.0\n",
+      "Iteration 1599 ... Loss tensor(0.3817, device='cuda:0', grad_fn=<NllLossBackward>) ... Accuracy 0.85\n",
+      "Iteration 1699 ... Loss tensor(0.0247, device='cuda:0', grad_fn=<NllLossBackward>) ... Accuracy 1.0\n",
+      "Iteration 1799 ... Loss tensor(0.0343, device='cuda:0', grad_fn=<NllLossBackward>) ... Accuracy 1.0\n",
+      "Iteration 1899 ... Loss tensor(0.0055, device='cuda:0', grad_fn=<NllLossBackward>) ... Accuracy 1.0\n",
+      "Iteration 1999 ... Loss tensor(0.0034, device='cuda:0', grad_fn=<NllLossBackward>) ... Accuracy 1.0\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Set the network to training mode\n",
+    "blob.net.train()\n",
+    "\n",
+    "# Let's train 2000 steps\n",
+    "stop_iteration = 2000\n",
+    "# Loop over data samples and into the network forward function\n",
+    "for i,data in enumerate(train_loader):\n",
+    "    # data and label\n",
+    "    blob.data, blob.label = data\n",
+    "    # call forward\n",
+    "    res = forward(blob,True)\n",
+    "    # once in a while, report\n",
+    "    if (i+1)%100 == 0:\n",
+    "        print('Iteration',i,'... Loss',res['loss'],'... Accuracy',res['accuracy'])\n",
+    "    if (i+1)==stop_iteration:\n",
+    "        break\n",
+    "    backward(blob)\n",
+    "    "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Evaluation\n",
+    "It seems that the network was trained well on the data set. Let's evaluate its performance on a separate data sample."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Accuracy mean: 0.9708 ... std: 0.04286443747443795\n"
+     ]
+    }
+   ],
+   "source": [
+    "# load the test dataset\n",
+    "dataset = datasets.MNIST(LOCAL_DATA_DIR, train=False, download=True,\n",
+    "                         transform=transforms.Compose([transforms.ToTensor()]))\n",
+    "# create DataLoader\n",
+    "test_loader = torch.utils.data.DataLoader(dataset,batch_size=20,shuffle=False,num_workers=1,pin_memory=True)\n",
+    "# set the network to test (non-train) mode\n",
+    "blob.net.eval()\n",
+    "# loop over test set, run forward for analysis\n",
+    "accuracy_array = []\n",
+    "for i,data in enumerate(test_loader):\n",
+    "    blob.data, blob.label = data\n",
+    "    res = forward(blob,True)\n",
+    "    accuracy_array.append(res['accuracy'])\n",
+    "\n",
+    "# report accuracy\n",
+    "accuracy_array = np.hstack(accuracy_array)\n",
+    "mean = accuracy_array.mean()\n",
+    "std  = accuracy_array.std()\n",
+    "print('Accuracy mean:',mean,'... std:',std)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
I added two more notebooks:
* Pytorch Dataset and DataLoader example using the workshop data
* MNIST digit classification using LeNet
... these complete the minimal set of notebook examples. Crap, I just remembered, maybe torch.Tensor would be another nice example...

One thing that I would like to modify is to link each notebook in the contents (e.g. say "go to [this notebook](link) to read about DataLoader"). That is better done when notebooks are in the final location (this repo is maybe final location?)